### PR TITLE
Handle Ozon product URL variations and request errors

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -3,22 +3,36 @@ import random
 import time
 import re
 from datetime import datetime
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
 # Набор user-agent'ов, чтобы не блокировали запросы
 USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1",
 ]
+
+
+def _build_headers() -> Dict[str, str]:
+    """Собирает заголовки, имитирующие реальные запросы браузера."""
+    return {
+        "User-Agent": random.choice(USER_AGENTS),
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Referer": "https://www.ozon.ru/",
+    }
 
 
 def extract_product_id(product_input: str) -> str:
     """Извлекает числовой ID товара из ссылки или строки."""
     if product_input.startswith("http"):
-        match = re.search(r"product/(\d+)", product_input)
+        match = re.search(r"product/(?:.*-)?(\d+)", product_input)
         if match:
             return match.group(1)
     elif product_input.isdigit():
@@ -26,22 +40,39 @@ def extract_product_id(product_input: str) -> str:
     raise ValueError("Невалидный ввод")
 
 
-def parse_ozon_reviews(product_input: str, max_reviews: int = 30) -> List[Dict]:
+def parse_ozon_reviews(
+    product_input: str, max_reviews: Optional[int] = None
+) -> List[Dict]:
     """Получает отзывы о товаре Ozon через внутренний API."""
     pid = extract_product_id(product_input)
     reviews: List[Dict] = []
     page = 1
-    session = requests.Session()
 
-    while len(reviews) < max_reviews:
+    session = requests.Session()
+    session.trust_env = False  # ignore proxy settings that may block requests
+    retries = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+
+    while True:
+        if max_reviews is not None and len(reviews) >= max_reviews:
+            break
+
         url = (
             "https://www.ozon.ru/api/composer-api.bx/page/json/v2?url="
             f"/product/{pid}/reviews&page={page}"
         )
-        headers = {"User-Agent": random.choice(USER_AGENTS)}
-        resp = session.get(url, headers=headers, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
+
+        try:
+            resp = session.get(url, headers=_build_headers(), timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+        except (requests.RequestException, ValueError, json.JSONDecodeError):
+            break
 
         widget_key = next(
             (k for k in data.get("widgetStates", {}) if k.startswith("webReview")),
@@ -49,6 +80,7 @@ def parse_ozon_reviews(product_input: str, max_reviews: int = 30) -> List[Dict]:
         )
         if not widget_key:
             break
+
         widget_data = json.loads(data["widgetStates"][widget_key])
 
         for item in widget_data.get("reviews", []):
@@ -63,14 +95,14 @@ def parse_ozon_reviews(product_input: str, max_reviews: int = 30) -> List[Dict]:
                     "text": item.get("text", ""),
                 }
             )
-            if len(reviews) >= max_reviews:
+            if max_reviews is not None and len(reviews) >= max_reviews:
                 break
 
         if not widget_data.get("paging", {}).get("nextPage"):
             break
 
         page += 1
-        time.sleep(random.uniform(0.5, 1.5))
+        time.sleep(random.uniform(1, 2))
 
     return reviews
 


### PR DESCRIPTION
## Summary
- Support Ozon product URLs that include a slug before the numeric ID
- Avoid proxy interference and gracefully handle request/JSON failures when fetching reviews
- Rotate realistic headers, add retries with backoff and allow unlimited review retrieval

## Testing
- `python -m py_compile app/parser.py`
- `python - <<'PY'
from app.parser import parse_ozon_reviews
res = parse_ozon_reviews('https://www.ozon.ru/product/myagkaya-plyushevaya-rozovaya-akula-80-sm-2043519082')
print('count', len(res))
print(res[:1])
PY`
- `curl -I https://www.ozon.ru 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f1f7d50908325a66656c443e98c8b